### PR TITLE
Implement delete employee by name feature

### DIFF
--- a/service-test/src/test/java/ivan/rest/example/definitionSteps/DeleteEmployeeByNameTest.java
+++ b/service-test/src/test/java/ivan/rest/example/definitionSteps/DeleteEmployeeByNameTest.java
@@ -1,0 +1,33 @@
+import static io.restassured.RestAssured.*;
+import static org.assertj.core.api.Assertions.*;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+public class DeleteEmployeeByNameTest {
+
+    @Test
+    public void testDeleteEmployeeByName() {
+        String nameToDelete = "John";
+        // Delete employee by name
+        Response deleteResponse = given()
+            .when()
+            .delete("/employee/byName/" + nameToDelete)
+            .then()
+            .extract()
+            .response();
+
+        // Verify deletion response
+        assertThat(deleteResponse.getStatusCode()).isEqualTo(204);
+
+        // Verify employee no longer exists
+        Response getResponse = given()
+            .when()
+            .get("/employee")
+            .then()
+            .extract()
+            .response();
+
+        List<Employee> employees = getResponse.jsonPath().getList("", Employee.class);
+        assertThat(employees).noneMatch(employee -> employee.getName().equals(nameToDelete));
+    }
+}

--- a/service-test/src/test/resources/features/deleteEmployeeByName.feature
+++ b/service-test/src/test/resources/features/deleteEmployeeByName.feature
@@ -1,0 +1,11 @@
+Feature: Delete Employee by Name
+
+  Scenario: Delete employee by name
+    Given employees added to Employee rest service repository:
+      | id  | name | passportNumber | education  |
+      | 108 | Tom  | TM123456       | University |
+      | 109 | Sam  | SM456789       | College    |
+      | 110 | John | JN789123       | School     |
+      | 111 | John | JN789123       | School     |
+    When employee with name "John" is deleted from the repository
+    Then the repository should not contain employees with name "John"


### PR DESCRIPTION
Added a new test case to verify that an employee can be deleted by their name. This includes:
- A new test class `DeleteEmployeeByNameTest`
- A feature file `deleteEmployeeByName.feature` to define the scenario

This implementation ensures that the employee is successfully deleted and no longer exists in the repository.